### PR TITLE
Don't process events with zero final damage

### DIFF
--- a/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
+++ b/src/main/java/com/gmail/nossr50/listeners/EntityListener.java
@@ -300,7 +300,11 @@ public class EntityListener implements Listener {
         double damage = event.getFinalDamage();
         Entity defender = event.getEntity();
         Entity attacker = event.getDamager();
-
+        
+        if(damage == 0) {
+                return;
+        }
+        
         if(WorldGuardUtils.isWorldGuardLoaded())
         {
             if(attacker instanceof Player) {
@@ -417,21 +421,6 @@ public class EntityListener implements Listener {
             ProjectileSource shooter = ((Projectile) attacker).getShooter();
             if(shooter instanceof LivingEntity) {
                 attacker = (LivingEntity) shooter;
-            }
-        }
-
-        /*
-         * This was put here to solve a plugin conflict with a mod called Project Korra
-         * Project Korra sends out a damage event with exactly 0 damage
-         * mcMMO does some calculations for the damage in an event and it ends up dividing by zero,
-         *  as a result of the modifiers for the event being 0 and the damage set for this event being 0.
-         *
-         * Surprising this kind of thing
-         *
-         */
-        if(mcMMO.isProjectKorraEnabled()) {
-            if(event.getFinalDamage() == 0) {
-                return;
             }
         }
 


### PR DESCRIPTION
I am having a compatibility issue with mcMMO. I pass an event with zero damage and check the continuous events using their name, but instead of the name I expect, I am getting hearts. Not only that, but I can't understand why you limited the zero check only for a specific plugin. My changes should make your plugin more compatible with other plugins that use EntityDamageByEntityEvent.